### PR TITLE
feat: Store user log entries in database

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 from flask import Flask
 from flask import render_template, request, redirect, url_for
-from datetime import date
-from test_alch import Category, SessionLocal
+from datetime import date # date from datetime is used for date objects
+from test_alch import Category, SessionLocal, LogEntry # Added LogEntry
 
 app = Flask(__name__)
 
@@ -26,7 +26,6 @@ def create_category():
         session.add(new_cat)
         session.commit()
         session.close()
-        # Save the new category...
         return redirect(url_for('index'))
 
     return render_template('create_category.html')
@@ -34,19 +33,53 @@ def create_category():
 #Ind. Category Stats
 @app.route('/category_stats/<int:category_id>')
 def category_stats(category_id):
-    category = categories[category_id - 1]
-    return render_template('category_stats.html', category=category)
+    session = SessionLocal()
+    category = session.query(Category).filter(Category.id == category_id).first()
+    # log_entries are accessed via category.log_entries due to the relationship
+    # No specific query for log_entries needed here if relationship is set up correctly
+    if category:
+        # Access log_entries here to ensure they are loaded before closing session if needed by template
+        log_entries = category.log_entries
+        session.close()
+        return render_template('category_stats.html', category=category, log_entries=log_entries)
+    else:
+        session.close()
+        return "Category not found", 404
 
 #Logger Form
 @app.route('/log/<int:category_id>', methods=['GET', 'POST'])
 def logger_form(category_id):
-    category = categories[category_id - 1]    
-    current_date = date.today().isoformat()
+    session = SessionLocal()
+    category = session.query(Category).filter(Category.id == category_id).first()
+
+    if not category:
+        session.close()
+        return "Category not found", 404
 
     if request.method == 'POST':
-        return redirect(url_for('index'))
+        form_date_str = request.form['date']
+        duration_str = request.form['duration']
+        notes = request.form.get('notes') # .get to handle optional notes
 
-    return render_template('logger_form.html', category=category, current_date=current_date)
+        # Convert data
+        entry_date = date.fromisoformat(form_date_str) # Use date.fromisoformat
+        duration_int = int(duration_str)
+
+        new_log_entry = LogEntry(
+            category_id=category.id, # Use the actual category.id
+            date=entry_date,
+            duration=duration_int,
+            notes=notes
+        )
+        session.add(new_log_entry)
+        session.commit()
+        session.close()
+        return redirect(url_for('category_stats', category_id=category_id))
+
+    # GET request
+    current_date_iso = date.today().isoformat() # from datetime.date
+    session.close() # Close session if only GET
+    return render_template('logger_form.html', category=category, current_date=current_date_iso)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/category_stats.html
+++ b/templates/category_stats.html
@@ -212,6 +212,24 @@
             <div class="stat-value">90</div>
         </div>
     </div>
+
+    <!-- Log Entries List -->
+    <h3>Log Entries</h3>
+    {% if log_entries %}
+        <ul>
+            {% for entry in log_entries %}
+                <li>
+                    <strong>Date:</strong> {{ entry.date.isoformat() }} |
+                    <strong>Duration:</strong> {{ entry.duration }} minutes |
+                    <strong>Notes:</strong> {{ entry.notes if entry.notes else 'N/A' }}
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>No log entries yet for this category.</p>
+    {% endif %}
+    <!-- End Log Entries List -->
+
     <script>
         function toggleMenu(e) {
           const menu = e.target.nextElementSibling;

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,14 +22,14 @@
         <div class="categories-list">
             {% for category in categories %}
                     <div class="category-card">
-                        <a href="{{ url_for('category_stats', category_id=loop.index) }}" class="category-link">
+                        <a href="{{ url_for('category_stats', category_id=category.id) }}" class="category-link">
                             <div class="category-icon">{{ category.icon }}</div>
                             <div class="category-details">
                                 <h3>{{ category.name }}</h3>
                                 <p>{{ category.description }}</p>
                             </div>
                         </a>
-                        <a href="{{ url_for('logger_form', category_id=loop.index) }}">
+                        <a href="{{ url_for('logger_form', category_id=category.id) }}">
                             <button class="log-btn">Log</button>
                         </a>                    
                     </div>

--- a/test_alch.py
+++ b/test_alch.py
@@ -1,15 +1,27 @@
-from sqlalchemy import create_engine, Column, Integer, String
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import create_engine, Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
 
 Base = declarative_base()
 
 class Category(Base):
     __tablename__ = 'categories'
 
-    id = Column(Integer, primary_key=True, autoincrement = True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String)
     description = Column(String)
     icon = Column(String)
+    log_entries = relationship("LogEntry", back_populates="category")
+
+class LogEntry(Base):
+    __tablename__ = 'log_entries'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    category_id = Column(Integer, ForeignKey('categories.id'))
+    date = Column(Date)
+    duration = Column(Integer)  # Duration in minutes
+    notes = Column(String, nullable=True)
+
+    category = relationship("Category", back_populates="log_entries")
 
 engine = create_engine('sqlite:///pl.db', echo=True)
 
@@ -32,3 +44,7 @@ SessionLocal = sessionmaker(bind=engine)
 
 
 # session.close()
+
+# Create all tables in the engine. This is equivalent to "Create Table"
+# statements in raw SQL.
+Base.metadata.create_all(engine)


### PR DESCRIPTION
Implement functionality to store user log entries into the SQLite database.

Key changes:
- Defined a `LogEntry` SQLAlchemy model in `test_alch.py` with fields for date, duration, notes, and a foreign key to the `Category` model.
- Established a one-to-many relationship between `Category` and `LogEntry`.
- Updated `app.py`:
    - The `/log/<category_id>` route now processes POST requests to save new log entries. It parses form data, creates `LogEntry` objects, and commits them to the database.
    - The `/category_stats/<category_id>` route now fetches and passes the associated log entries for the given category to its template.
- Modified `templates/category_stats.html` to display the list of log entries for a category.
- Updated `templates/index.html` to use `category.id` for URL generation, ensuring correct linking.
- Added `Base.metadata.create_all(engine)` to `test_alch.py` to ensure automatic table creation.