### PR TITLE
feat: Enhance category statistics page

### DIFF
--- a/templates/category_stats.html
+++ b/templates/category_stats.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Category Stats</title>
+    <title>{{ category.name }} Stats</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}"> <!-- Assuming general styles are here -->
     <style>
-        /* General Styling */
+        /* General Styling from original kept, can be moved to styles.css */
         body {
             font-family: 'Arial', sans-serif;
             margin: 0;
@@ -13,8 +14,6 @@
             background-color: #f4f7f6;
             color: #333;
         }
-
-        /* Header Section */
         .header {
             display: flex;
             justify-content: space-between;
@@ -23,135 +22,62 @@
             border-bottom: 2px solid #eee;
             margin-bottom: 1.5rem;
         }
-
-        .header h2 {
-            margin: 0;
-            font-size: 1.8rem;
-            font-weight: 600;
-        }
-
-        .more-menu-wrapper {
-            position: relative;
-            display: inline-block;
-            margin-left: 0.5rem;
-        }
-
-        .more-menu {
-            cursor: pointer;
-            font-size: 1.4rem;
-            background: none;
-            border: none;
-            padding: 0.2rem;
-            line-height: 1;
-        }
-
-        .menu-options {
-            display: none;
-            position: absolute;
-            top: 120%;
-            right: 0;
-            background-color: white;
-            border: 1px solid #ccc;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-            border-radius: 5px;
-            min-width: 100px;
-            z-index: 1000;
-        }
-
-        .menu-options div {
-            padding: 0.5rem 0.75rem;
-            cursor: pointer;
-            font-size: 0.95rem;
-        }
-
-        .menu-options div:hover {
-            background-color: #f0f0f0;
-        }
-
-        .show-menu {
-            display: block;
-        }
-
-        .left-header {
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-
+        .header h2 { margin: 0; font-size: 1.8rem; font-weight: 600; }
+        .left-header { display: flex; align-items: center; gap: 0.5rem; }
         .month-selector {
-            font-size: 1rem;
-            padding: 0.5rem;
-            border-radius: 5px;
-            border: 1px solid #ccc;
-            background-color: white;
-            cursor: pointer;
+            font-size: 1rem; padding: 0.5rem; border-radius: 5px;
+            border: 1px solid #ccc; background-color: white; cursor: pointer;
         }
-
-
-        /* Calendar Section */
         .calendar {
-            display: grid;
-            grid-template-columns: repeat(7, 1fr);
-            gap: 0.5rem;
-            margin-bottom: 2rem;
+            display: grid; grid-template-columns: repeat(7, 1fr);
+            gap: 0.5rem; margin-bottom: 1rem; /* Reduced margin */
         }
-
         .day {
-            width: 40px;
-            height: 40px;
-            border-radius: 50%;
-            background-color: #e0e0e0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 0.9rem;
-            color: #333;
+            width: 40px; height: 40px; border-radius: 50%;
+            background-color: #e0e0e0; display: flex; align-items: center;
+            justify-content: center; font-size: 0.9rem; color: #333;
             transition: background-color 0.2s ease;
+        }
+        .day.day-active { /* New class for active days */
+            background-color: orange;
+            color: white;
             cursor: pointer;
         }
-
-        .day.filled {
-            background-color: #4caf50;
-            color: white;
+        .day.day-inactive { /* For days not part of the month */
+            background-color: #f0f0f0;
+            visibility: hidden; /* Or some other styling to show it's not part of month */
         }
-
         .weekdays {
-            display: grid;
-            grid-template-columns: repeat(7, 1fr);
-            text-align: center;
-            font-weight: 600;
-            margin-bottom: 1rem;
+            display: grid; grid-template-columns: repeat(7, 1fr);
+            text-align: center; font-weight: 600; margin-bottom: 0.5rem; /* Reduced margin */
         }
-
-        /* Stats Section */
         .stats-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 1rem;
+            display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); /* Responsive */
+            gap: 1rem; margin-bottom: 2rem;
         }
-
         .stat-box {
-            background-color: #fff;
-            border-radius: 10px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-            padding: 1.5rem;
-            text-align: center;
-            font-size: 1.2rem;
+            background-color: #fff; border-radius: 10px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            padding: 1.5rem; text-align: center; font-size: 1.2rem;
         }
+        .stat-box h4 { margin: 0 0 0.5rem 0; font-size: 1.1rem; color: #555; font-weight: 600; }
+        .stat-box .stat-value { font-size: 2rem; font-weight: 700; color: #333; }
 
-        .stat-box h4 {
-            margin: 0;
-            font-size: 1.1rem;
-            color: #555;
-            font-weight: 600;
+        #daily-log-display {
+            margin-top: 1.5rem; padding: 1rem; background-color: #fff;
+            border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);
         }
-
-        .stat-box .stat-value {
-            margin-top: 0.5rem;
-            font-size: 2rem;
-            font-weight: 700;
-            color: #333;
+        #daily-log-display h4 { margin-top: 0; }
+        #daily-log-list li {
+            padding: 0.5rem 0;
+            border-bottom: 1px solid #eee;
         }
+        #daily-log-list li:last-child { border-bottom: none; }
+        .more-menu-wrapper { position: relative; display: inline-block; margin-left: 0.5rem; }
+        .more-menu { cursor: pointer; font-size: 1.4rem; background: none; border: none; padding: 0.2rem; line-height: 1; }
+        .menu-options { display: none; position: absolute; top: 120%; right: 0; background-color: white; border: 1px solid #ccc; box-shadow: 0 2px 5px rgba(0,0,0,0.1); border-radius: 5px; min-width: 100px; z-index: 1000; }
+        .menu-options div { padding: 0.5rem 0.75rem; cursor: pointer; font-size: 0.95rem; }
+        .menu-options div:hover { background-color: #f0f0f0; }
+        .show-menu { display: block; }
 
     </style>
 </head>
@@ -159,92 +85,177 @@
 
     <div class="header">
         <div class="left-header">
-            <h2>{{ category["name"] }} Stats</h2>
+            <h2>{{ category.name }} Stats</h2> <!-- Use category.name -->
             <div class="more-menu-wrapper">
                 <button class="more-menu" onclick="toggleMenu(event)">⋮</button>
                 <div class="menu-options">
-                    <div>Edit</div>
-                    <div>Delete</div>
+                    <div>Edit Category</div> <!-- Placeholder -->
+                    <div>Delete Category</div> <!-- Placeholder -->
                 </div>
             </div>
         </div>
     
-        <select class="month-selector">
-            <option>May 2025</option>
-            <option>April 2025</option>
-            <option>March 2025</option>
+        <select class="month-selector" id="month-selector">
+            {% if available_months %}
+                {% for month_str in available_months %}
+                    <option value="{{ month_str }}">{{ month_str }}</option>
+                {% endfor %}
+            {% else %}
+                <option value="">No data</option>
+            {% endif %}
         </select>
     </div>
     
-
-
     <!-- Calendar Section -->
     <div class="weekdays">
         <div>Sun</div><div>Mon</div><div>Tue</div><div>Wed</div><div>Thu</div><div>Fri</div><div>Sat</div>
     </div>
+    <div class="calendar" id="calendar-grid">
+        <!-- Calendar days will be generated by JavaScript -->
+    </div>
 
-    <div class="calendar">
-        <!-- Empty days before the 1st of May (May starts on Thursday) -->
-        <div></div><div></div><div></div><div></div>
-
-        <!-- Example filled days (practiced) -->
-        {% for day in range(1, 32) %}
-            <div class="day {% if day in [2, 4, 10, 15, 22] %}filled{% endif %}">{{ day }}</div>
-        {% endfor %}
+    <!-- Daily Log Display Area (Initially Hidden) -->
+    <div id="daily-log-display" style="display:none;">
+        <h4>Logs for <span id="selected-log-date"></span></h4>
+        <ul id="daily-log-list"></ul>
     </div>
 
     <!-- Stats Section -->
     <div class="stats-grid">
         <div class="stat-box">
             <h4>Total Sessions</h4>
-            <div class="stat-value">18</div>
+            <div class="stat-value" id="total-sessions">{{ lifetime_stats.total_sessions }}</div>
         </div>
         <div class="stat-box">
             <h4>Lifetime Time Spent (hrs)</h4>
-            <div class="stat-value">34</div>
+            <div class="stat-value" id="total-hours-spent">{{ lifetime_stats.total_hours_spent }}</div>
         </div>
         <div class="stat-box">
             <h4>Avg. Per Week (hrs)</h4>
-            <div class="stat-value">3.2</div>
+            <div class="stat-value" id="avg-hours-week">{{ lifetime_stats.avg_hours_per_week }}</div>
         </div>
         <div class="stat-box">
             <h4>Longest Session (min)</h4>
-            <div class="stat-value">90</div>
+            <div class="stat-value" id="longest-session">{{ lifetime_stats.longest_session_minutes }}</div>
         </div>
     </div>
 
-    <!-- Log Entries List -->
-    <h3>Log Entries</h3>
-    {% if log_entries %}
-        <ul>
-            {% for entry in log_entries %}
-                <li>
-                    <strong>Date:</strong> {{ entry.date.isoformat() }} |
-                    <strong>Duration:</strong> {{ entry.duration }} minutes |
-                    <strong>Notes:</strong> {{ entry.notes if entry.notes else 'N/A' }}
-                </li>
-            {% endfor %}
-        </ul>
-    {% else %}
-        <p>No log entries yet for this category.</p>
-    {% endif %}
-    <!-- End Log Entries List -->
+    <!-- Old Log Entries List REMOVED -->
 
     <script>
-        function toggleMenu(e) {
-          const menu = e.target.nextElementSibling;
+        const logEntriesData = {{ log_entries_data | tojson }};
+        const availableMonths = {{ available_months | tojson }};
+        const calendarGrid = document.getElementById('calendar-grid');
+        const monthSelector = document.getElementById('month-selector');
+        const dailyLogDisplay = document.getElementById('daily-log-display');
+        const selectedLogDateEl = document.getElementById('selected-log-date');
+        const dailyLogListEl = document.getElementById('daily-log-list');
+
+        function renderCalendar(yearMonth) { // yearMonth is "YYYY-MM"
+            calendarGrid.innerHTML = ''; // Clear previous calendar
+            dailyLogDisplay.style.display = 'none'; // Hide daily logs when month changes
+
+            if (!yearMonth || !logEntriesData[yearMonth]) {
+                // Handle case where there's no data for selected month or no month selected
+                // (e.g. if availableMonths is empty)
+                if (availableMonths && availableMonths.length > 0 && !yearMonth) {
+                    yearMonth = availableMonths[0]; // Default to first available if nothing selected
+                } else if (!logEntriesData[yearMonth]) {
+                     // If still no data for the month (e.g. "No data" option was selected or data structure is empty)
+                    calendarGrid.innerHTML = '<p>No log data for this period.</p>';
+                    return;
+                }
+            }
+
+            const [year, month] = yearMonth.split('-').map(Number);
+            const firstDayOfMonth = new Date(year, month - 1, 1).getDay(); // 0 (Sun) - 6 (Sat)
+            const daysInMonth = new Date(year, month, 0).getDate(); // Last day of prev month = days in current
+
+            // Add empty divs for days before the first day of the month
+            for (let i = 0; i < firstDayOfMonth; i++) {
+                const emptyDayCell = document.createElement('div');
+                emptyDayCell.classList.add('day', 'day-inactive');
+                calendarGrid.appendChild(emptyDayCell);
+            }
+
+            // Add day cells for the month
+            for (let dayNum = 1; dayNum <= daysInMonth; dayNum++) {
+                const dayCell = document.createElement('div');
+                dayCell.classList.add('day');
+                dayCell.textContent = dayNum;
+
+                const dayHasLogs = logEntriesData[yearMonth] && logEntriesData[yearMonth][dayNum] && logEntriesData[yearMonth][dayNum].length > 0;
+
+                if (dayHasLogs) {
+                    dayCell.classList.add('day-active');
+                    dayCell.dataset.date = `${yearMonth}-${String(dayNum).padStart(2, '0')}`; // YYYY-MM-DD
+                    dayCell.addEventListener('click', function() {
+                        displayDailyLogs(this.dataset.date);
+                    });
+                }
+                calendarGrid.appendChild(dayCell);
+            }
+        }
+
+        function displayDailyLogs(dateStr) { // dateStr is "YYYY-MM-DD"
+            const [year, month, day] = dateStr.split('-');
+            const yearMonthKey = `${year}-${month}`;
+            const dayKey = parseInt(day);
+
+            const entriesForDay = logEntriesData[yearMonthKey] && logEntriesData[yearMonthKey][dayKey]
+                                ? logEntriesData[yearMonthKey][dayKey]
+                                : [];
+
+            selectedLogDateEl.textContent = dateStr;
+            dailyLogListEl.innerHTML = ''; // Clear previous logs
+
+            if (entriesForDay.length > 0) {
+                entriesForDay.forEach(entry => {
+                    const listItem = document.createElement('li');
+                    listItem.innerHTML = `<strong>Duration:</strong> ${entry.duration} min. <br>
+                                          <strong>Notes:</strong> ${entry.notes ? entry.notes : 'N/A'}`;
+                    dailyLogListEl.appendChild(listItem);
+                });
+            } else {
+                dailyLogListEl.innerHTML = '<li>No specific entries found for this day (this shouldn\'t happen if day was active).</li>';
+            }
+            dailyLogDisplay.style.display = 'block';
+        }
+
+        monthSelector.addEventListener('change', function() {
+            renderCalendar(this.value);
+        });
+
+        // Initial render
+        if (availableMonths && availableMonths.length > 0) {
+            monthSelector.value = availableMonths[0]; // Select first month by default
+            renderCalendar(availableMonths[0]);
+        } else {
+            calendarGrid.innerHTML = '<p>No log entries for this category yet.</p>';
+            // Optionally disable month selector if no months
+            if(monthSelector.options.length === 1 && monthSelector.options[0].value === "") {
+                monthSelector.disabled = true;
+            }
+        }
+
+        // --- More Menu Toggle ---
+        function toggleMenu(event) {
+          event.stopPropagation(); // Prevent click from immediately closing menu
+          const menu = event.target.nextElementSibling;
           const allMenus = document.querySelectorAll('.menu-options');
+          // Hide other menus
           allMenus.forEach(m => {
             if (m !== menu) m.classList.remove('show-menu');
           });
+          // Toggle current menu
           menu.classList.toggle('show-menu');
         }
     
-        // Close menu if clicked outside
         document.addEventListener('click', function(e) {
-          const isMenu = e.target.closest('.menu-options');
-          const isButton = e.target.closest('.more-menu');
-          if (!isMenu && !isButton) {
+          const isMenuButton = e.target.classList.contains('more-menu');
+          const isInsideMenu = e.target.closest('.menu-options');
+
+          if (!isMenuButton && !isInsideMenu) {
             document.querySelectorAll('.menu-options').forEach(menu => menu.classList.remove('show-menu'));
           }
         });


### PR DESCRIPTION
Implemented a comprehensive update to the category statistics page, including a dynamic monthly calendar, daily log drill-down, and accurate lifetime statistics.

Key changes:

Backend (app.py):
- The `category_stats` route now processes all log entries for a category.
- Generates a list of available months with log activity.
- Groups log entries by month and day (`entries_by_month_day`).
- Calculates lifetime statistics:
    - Total logged sessions.
    - Total time spent (in hours, rounded up).
    - Average hours logged per week (calculated over the span of activity).
    - Longest single session duration (in minutes).
- Passes this structured data to the template.

Frontend (templates/category_stats.html):
- Replaced the static calendar and old log list.
- Dynamically populates a month selector dropdown based on months with data.
- JavaScript functions now render a monthly calendar:
    - Days with log entries are highlighted (orange) and clickable.
    - Days without entries or outside the current month are styled appropriately.
- Clicking an active day in the calendar displays all log entries (duration, notes) for that specific day in a designated section.
- Lifetime statistics are now accurately displayed using data from the backend.
- Handles cases with no log entries or no data for a selected month.
- CSS updated for new calendar day states and daily log display.